### PR TITLE
Fix both Dry deposition and Wet deposition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtmosphericDeposition"
 uuid = "1a52f20c-0d16-41d8-a00a-b2996d86a462"
 authors = ["EarthSciML authors and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtmosphericDeposition"
 uuid = "1a52f20c-0d16-41d8-a00a-b2996d86a462"
 authors = ["EarthSciML authors and contributors"]
-version = "0.2.2"
+version = "0.2.4"
 
 [deps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
@@ -27,7 +27,7 @@ DataInterpolations = "6"
 DifferentialEquations = "7"
 DynamicQuantities = "1"
 EarthSciData = "0.12"
-EarthSciMLBase = "0.20"
+EarthSciMLBase = "0.20, 0.21"
 GasChem = "0.9"
 ModelingToolkit = "9"
 SafeTestsets = "0.1"

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -19,16 +19,17 @@ function EarthSciMLBase.couple2(d::AtmosphericDeposition.DrydepositionGCoupler, 
 
     # Monin-Obhukov length = -Air density * Cp * T(surface air) * Ustar^3/（vK   * g  * Sensible Heat flux）
 
-    d = param_to_var(d, :T, :z, :z₀, :u_star, :G, :ρA, :L)
+    d = param_to_var(d, :T, :z, :z₀, :u_star, :G, :ρA, :L, :lev)
 
     ConnectorSystem([
             d.T ~ g.I3₊T,
-            d.z ~ g.A1₊PBLH,
+            d.z ~ 0.1 * g.A1₊PBLH,
             d.z₀ ~ g.A1₊Z0M,
             d.u_star ~ g.A1₊USTAR,
             d.G ~ g.A1₊SWGDN,
             d.ρA ~ g.P/(g.I3₊T*R)*MW_air,
             d.L ~ -g.P/(g.I3₊T*R)*MW_air * Cp * g.A1₊TS * (g.A1₊USTAR)^3/(vK*gg*g.A1₊HFLUX),
+            d.lev ~ g.lev,
         ], d, g)
 end
 

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -23,7 +23,7 @@ function EarthSciMLBase.couple2(d::AtmosphericDeposition.DrydepositionGCoupler, 
 
     ConnectorSystem([
             d.T ~ g.I3₊T,
-            d.z ~ 0.1 * g.A1₊PBLH,
+            d.z ~ 0.1 * g.A1₊PBLH, # the surface layer height is 10% of the boundary layer height
             d.z₀ ~ g.A1₊Z0M,
             d.u_star ~ g.A1₊USTAR,
             d.G ~ g.A1₊SWGDN,

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -49,11 +49,12 @@ function EarthSciMLBase.couple2(d::AtmosphericDeposition.WetdepositionCoupler, g
     # From EMEP algorithm: P = QRAIN * Vdr * ρgas => QRAIN = P / Vdr / ρgas
     # kg*m-2*s-1/(m/s)/(kg/m3)
 
-    d = param_to_var(d, :cloudFrac, :ρ_air, :qrain)
+    d = param_to_var(d, :cloudFrac, :ρ_air, :qrain, :lev)
     ConnectorSystem([
             d.cloudFrac ~ g.A3cld₊CLOUD,
             d.ρ_air ~ g.P/(g.I3₊T*R)*MW_air,
             d.qrain ~ (g.A3mstE₊PFLCU + g.A3mstE₊PFLLSAN) / Vdr / (g.P/(g.I3₊T*R)*MW_air),
+            d.lev ~ g.lev,
         ], d, g)
 end
 

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -1,8 +1,34 @@
-export WetDeposition, Wetdeposition, wd_defaults
+export WetDeposition, Wetdeposition, wd_defaults, get_lev_depth
 
 @constants A_wd = 5.2 [unit = u"m^3/kg/s", description = "Empirical coefficient"]
 @constants ρwater = 1000.0 [unit = u"kg*m^-3", description = "water density"]
 @constants Vdr = 5.0 [unit = u"m/s", description = "raindrop fall speed"]
+
+const lev_depth = [123.66503647136699, 126.1276322862293, 127.81793001768432, 129.5320284164788, 131.3096296124803, 
+    133.16517799136489, 135.08768602272573, 137.10796269057562, 139.21228482592755, 141.44376989951024, 
+    143.7574669454459, 146.11933204200864, 198.54224783503264, 254.42969509717796, 261.67340274464914, 
+    269.231033059717, 277.3039413513152, 285.9069077030176, 446.4439568700527, 469.32492993415644, 
+    494.6124439883338, 522.6842502004765, 554.6091144685597, 591.0927240282208, 633.2768512023067, 
+    682.3924743496791, 741.7294428383548, 1090.491426716162, 1091.224127316289, 1063.1347680566032, 
+    1038.8233086979671, 1024.2528747829, 1011.555297383451, 1001.2550381718829, 993.8747259925203, 
+    988.6668674973989, 1000.6772919922369, 1018.1853036083521, 1038.4077259678052, 1060.279636055635, 
+    1080.0011699235038, 1105.2749220476362, 1128.8308686418932, 1150.9605352645412, 1174.281709164923, 
+    1196.5658056986103, 1220.477376106457, 1248.055139801716, 1289.3240338666546, 1330.1699211514533, 
+    1371.1351955508508, 1418.9073193940494, 1469.6721949144776, 1524.1720211194188, 1589.3067557895556, 
+    1669.0982349095284, 1748.6026372218985, 1819.7984799666592, 1873.109532132221, 1911.520986089934, 
+    1927.4499053974941, 1929.2166042272438, 1929.6506325142327, 1932.4995109991505, 1946.1510743334002, 
+    1971.4849133077078, 1995.6526762815556, 2040.0593226684432, 2158.2645757768187, 2421.761343639795, 
+    3116.2739840471622, 4343.478215407085] # unit: m. The depth of each level.
+
+function get_lev_depth(lev)
+    j = 0
+    for i in 1:length(lev_depth)
+        j += ifelse(i <= lev, 1, 0)
+    end
+    result = lev_depth[j]
+    return result
+end
+@register_symbolic get_lev_depth(lev)
 
 """
 Calculate wet deposition based on formulas at
@@ -61,8 +87,10 @@ function Wetdeposition(; name=:Wetdeposition)
         cloudFrac = 0.5, [description = "fraction of grid cell covered by clouds"],
         qrain = 0.5, [description = "rain mixing ratio"],
         ρ_air = 1.204, [unit = u"kg*m^-3", description = "air density"],
-        Δz = 200, [unit = u"m", description = "fall distance"],
+        lev = 1, [description = "level of the grid cell"],
     )
+
+    @constants Δz_unit = 1 [unit = u"m", description = "unit of depth"]
 
     D = Differential(t)
 
@@ -77,11 +105,11 @@ function Wetdeposition(; name=:Wetdeposition)
 
     eqs = [
         #TODO: D(SO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2] * SO2, Add SO2 back to the model when aerosol model is implemented
-        D(O3) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * O3
-        D(NO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * NO2
-        D(H2O2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * H2O2
-        D(HNO3) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * HNO3
-        D(CH2O) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * CH2O
+        D(O3) ~ -WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3] * O3
+        D(NO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3] * NO2
+        D(H2O2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3] * H2O2
+        D(HNO3) ~ -WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3] * HNO3
+        D(CH2O) ~ -WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3] * CH2O
     ]
 
     ODESystem(eqs, t, vars, params; name=name,

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -21,6 +21,8 @@ function WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     wInParticle = 1.0 # in-cloud scavanging ratio
     wInOther = 1.4   # in-cloud scavanging ratio
 
+    i = ifelse(qrain > 0, 1, 0) # index to check if rain is present, avoid negative qrain
+
     # precalculated constant combinations
     AE = A_wd * E
     wSubSO2VdrPerρwater = wSubSO2 * Vdr / ρwater
@@ -33,9 +35,9 @@ function WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     # wdGas (subcloud) = wSub * P / Δz / ρwater = wSub * QRAIN * Vdr * ρgas / Δz / ρwater
     # wd (in-cloud) = wIn * P / Δz / ρwater = wIn * QRAIN * Vdr * ρgas / Δz / ρwater
 
-    wdParticle = qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / Δz))
-    wdSO2 = (wSubSO2VdrPerρwater + cloudFrac * wSubSO2VdrPerρwater) * qrain * ρ_air / Δz
-    wdOtherGas = (wSubOtherVdrPerρwater + cloudFrac * wSubOtherVdrPerρwater) * qrain * ρ_air / Δz
+    wdParticle = i * qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / Δz))
+    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wSubSO2VdrPerρwater) * qrain * ρ_air / Δz
+    wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wSubOtherVdrPerρwater) * qrain * ρ_air / Δz
 
     return wdParticle, wdSO2, wdOtherGas
 end

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -65,7 +65,7 @@ function Wetdeposition(; name=:Wetdeposition)
     D = Differential(t)
 
     vars = @variables(
-        SO2(t) = 2, [unit = u"ppb"],
+        #TODO: SO2(t) = 2, [unit = u"ppb"], Add SO2 back to the model when aerosol model is implemented
         O3(t) = 10, [unit = u"ppb"],
         NO2(t) = 10, [unit = u"ppb"],
         H2O2(t) = 2.34, [unit = u"ppb"],
@@ -74,7 +74,7 @@ function Wetdeposition(; name=:Wetdeposition)
     )
 
     eqs = [
-        D(SO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2] * SO2
+        #TODO: D(SO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2] * SO2, Add SO2 back to the model when aerosol model is implemented
         D(O3) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * O3
         D(NO2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * NO2
         D(H2O2) ~ -WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3] * H2O2

--- a/test/connector_test.jl
+++ b/test/connector_test.jl
@@ -12,7 +12,7 @@ domain = DomainInfo(DateTime(2022, 1, 1), DateTime(2022, 1, 3);
     composed_ode = couple(SuperFast(), FastJX(), DrydepositionG(), Wetdeposition())
     sys = convert(ODESystem, composed_ode)
     print(unknowns(sys))
-    @test length(unknowns(sys)) ≈ 15
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(equations(sys))
     wanteqs = ["Differential(t)(SuperFast₊O3(t)) ~ SuperFast₊DrydepositionG_ddt_O3ˍt(t) + SuperFast₊Wetdeposition_ddt_O3ˍt(t)"]
@@ -29,7 +29,7 @@ end
     model = couple(SuperFast(), FastJX(), geosfp, Wetdeposition(), DrydepositionG())
 
     sys = convert(ODESystem, model)
-    @test length(unknowns(sys)) ≈ 15
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(observed(sys))
     wanteq = "DrydepositionG₊G(t) ~ GEOSFP₊A1₊SWGDN(t)"

--- a/test/connector_test.jl
+++ b/test/connector_test.jl
@@ -12,7 +12,7 @@ domain = DomainInfo(DateTime(2022, 1, 1), DateTime(2022, 1, 3);
     composed_ode = couple(SuperFast(), FastJX(), DrydepositionG(), Wetdeposition())
     sys = convert(ODESystem, composed_ode)
     print(unknowns(sys))
-    @test length(unknowns(sys)) ≈ 14
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(equations(sys))
     wanteqs = ["Differential(t)(SuperFast₊O3(t)) ~ SuperFast₊DrydepositionG_ddt_O3ˍt(t) + SuperFast₊Wetdeposition_ddt_O3ˍt(t)"]
@@ -29,7 +29,7 @@ end
     model = couple(SuperFast(), FastJX(), geosfp, Wetdeposition(), DrydepositionG())
 
     sys = convert(ODESystem, model)
-    @test length(unknowns(sys)) ≈ 14
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(observed(sys))
     wanteq = "DrydepositionG₊G(t) ~ GEOSFP₊A1₊SWGDN(t)"

--- a/test/drydep_test.jl
+++ b/test/drydep_test.jl
@@ -14,6 +14,7 @@ begin
     @parameters ρA [unit = u"kg*m^-3"]
     @parameters G [unit = u"W*m^-2"]
     @parameters θ, iLandUse, iSeason
+    @parameters lev 
 end
 
 @testset "mfp" begin
@@ -25,7 +26,7 @@ end
 @testset "unit" begin
     @test ModelingToolkit.get_unit(dH2O(T)) == u"m^2/s"
     @test ModelingToolkit.get_unit(DryDepParticle(z, z₀, u_star, L, Dp, T, P, ρParticle, ρA, 1, 1)) == u"m/s"
-    @test ModelingToolkit.get_unit(DryDepGas(z, z₀, u_star, L, ρA, AtmosphericDeposition.So2Data, G, T, θ, iSeason, iLandUse, false, false, true, false)) == u"m/s"
+    @test ModelingToolkit.get_unit(DryDepGas(lev,z, z₀, u_star, L, ρA, AtmosphericDeposition.So2Data, G, T, θ, iSeason, iLandUse, false, false, true, false)) == u"m/s"
 end
 
 @testset "viscosity" begin
@@ -69,7 +70,7 @@ end
 
 @testset "DryDepGas" begin
     vd_true = 0.03 # m/s
-    @test (substitute(DryDepGas(z, z₀, u_star, L, ρA, AtmosphericDeposition.No2Data, G, T, 0, iSeason, iLandUse, false, false, false, false), Dict(z => 50, z₀ => 0.04, u_star => 0.44, L => 0, T => 298, ρA => 1.2, G => 300, iSeason => 1, iLandUse => 10, AtmosphericDeposition.defaults...)) - vd_true) / vd_true < 0.33
+    @test (substitute(DryDepGas(lev, z, z₀, u_star, L, ρA, AtmosphericDeposition.No2Data, G, T, 0, iSeason, iLandUse, false, false, false, false), Dict(lev => 1, z => 50, z₀ => 0.04, u_star => 0.44, L => 0, T => 298, ρA => 1.2, G => 300, iSeason => 1, iLandUse => 10, AtmosphericDeposition.defaults...)) - vd_true) / vd_true < 0.33
 end
 
 @testset "DryDepParticle" begin

--- a/test/wetdep_test.jl
+++ b/test/wetdep_test.jl
@@ -12,3 +12,7 @@ using Test, DynamicQuantities, ModelingToolkit
     @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2]) == u"s^-1"
     @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3]) == u"s^-1"
 end
+
+@testset "WetDeposition" begin
+    @test substitute(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1], Dict(cloudFrac => 0.5, qrain => -1e5, ρ_air => 1.204, Δz => 200, wd_defaults...)) ≈ 0.0
+end

--- a/test/wetdep_test.jl
+++ b/test/wetdep_test.jl
@@ -5,14 +5,19 @@ using Test, DynamicQuantities, ModelingToolkit
 @parameters qrain = 0.5
 @parameters ρ_air = 1.204 [unit = u"kg*m^-3"]
 @parameters Δz = 200 [unit = u"m"]
+@parameters lev 
+
+@constants Δz_unit = 1 [unit = u"m", description = "unit of depth"]
 
 @testset "unit" begin
     @test substitute(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1], Dict(cloudFrac => 0.5, qrain => 0.5, ρ_air => 1.204, Δz => 200, wd_defaults...)) ≈ 0.313047525
     @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1]) == u"s^-1"
     @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2]) == u"s^-1"
     @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[3]) == u"s^-1"
+    @test ModelingToolkit.get_unit(WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev)*Δz_unit)[3]) == u"s^-1"
 end
 
 @testset "WetDeposition" begin
     @test substitute(WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1], Dict(cloudFrac => 0.5, qrain => -1e5, ρ_air => 1.204, Δz => 200, wd_defaults...)) ≈ 0.0
+    @test substitute(get_lev_depth(lev), Dict(lev => 3)) ≈ 127.81793001768432
 end


### PR DESCRIPTION
Dry deposition changes:
1. Correct z = 10% * PBLH
2. Fix the Error: Incorrect implementation of the when z/L > 1 & z/L < -1.
3. Remove SO2 deposition calculation
4. Perform dry deposition only at level 1. This could be refined after discussion.

Wet deposition changes:
1. Prevent negative wet deposition rates caused by negative `qrain` values [`A3mstE["PFLCU"]`
`A3mstE["PFLLSAN"]`]from GEOS-FP. 
2. Correctly compute Δz values at different levels.
