### PR TITLE
Add dry and wet deposition for HNO3

### DIFF
--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -7,6 +7,7 @@ function EarthSciMLBase.couple2(c::GasChem.SuperFastCoupler, d::AtmosphericDepos
 
     operator_compose(convert(ODESystem, c), d, Dict(
         #c.SO2 => d.SO2, # SuperFast does not currently have SO2
+        c.HNO3 => d.HNO3,
         c.NO2 => d.NO2,
         c.O3 => d.O3,
         c.H2O2 => d.H2O2,
@@ -19,6 +20,7 @@ function EarthSciMLBase.couple2(c::GasChem.SuperFastCoupler, d::AtmosphericDepos
 
     operator_compose(convert(ODESystem, c), d, Dict(
         #c.SO2 => d.SO2, # SuperFast does not currently have SO2
+        c.HNO3 => d.HNO3,
         c.NO2 => d.NO2,
         c.O3 => d.O3,
         c.H2O2 => d.H2O2,


### PR DESCRIPTION
Based on Makoto's, 

> Standard GEOS-Chem modules for dry deposition (Bey et al., [2001](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0002)) and wet deposition (Amos et al., [2012](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0001); Liu et al., [2001](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0030)) are applied to CH2O, H2O2, O3, NO2, and HNO3.