### PR TITLE
Add HNO3 for Deposition

### DIFF
--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -33,7 +33,7 @@ function EarthSciMLBase.couple2(
         d,
         Dict(
             #c.SO2 => d.k_SO2 => c.SO2, # SuperFast does not currently have SO2
-            c.HNO3 => d.k_NO3 => c.HNO3,
+            c.HNO3 => d.k_othergas => c.HNO3,
             c.NO2 => d.k_othergas => -c.NO2,
             c.O3 => d.k_othergas => -c.O3,
             c.H2O2 => d.k_othergas => -c.H2O2,


### PR DESCRIPTION
Based on Makoto's paper: 

> Standard GEOS-Chem modules for dry deposition (Bey et al., [2001](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0002)) and wet deposition (Amos et al., [2012](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0001); Liu et al., [2001](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002926#jame21620-bib-0030)) are applied to CH2O, H2O2, O3, NO2, and HNO3.