### PR TITLE
Add Constant extrapolation to obtain_value LinearInterpolation

### DIFF
--- a/src/wesley1989.jl
+++ b/src/wesley1989.jl
@@ -238,7 +238,8 @@ const RCOOHData = GasData(2.027959554, 1520.0, 1.0)
 # Obtain values from matrix using symbolic parameter iSeason and iLandUse
 function obtain_value(iSeason, iLandUse, matrix)
     index = (iLandUse - 1) * 5 + iSeason
-    interpolate_r_i = DataInterpolations.LinearInterpolation(vec(matrix), 1:55)
+    interpolate_r_i = DataInterpolations.LinearInterpolation(vec(matrix), 1:55;
+        extrapolation = DataInterpolations.ExtrapolationType.Constant)
     return interpolate_r_i(index)
 end
 


### PR DESCRIPTION
## Summary
- Add `Constant` extrapolation to the `DataInterpolations.LinearInterpolation` in `obtain_value` in `wesley1989.jl`
- The interpolation was created with default `ExtrapolationType.None`, which throws an error for any index outside [1, 55]
- This causes failures when used in coupled ModelingToolkit systems (e.g., the earthsci.dev optimization example) where the computed index `(iLandUse - 1) * 5 + iSeason` may fall at or slightly below the lower boundary during Jacobian evaluation

## Test plan
- [ ] Verify existing tests pass
- [ ] Verify the earthsci.dev optimization.md example no longer fails with "Cannot extrapolate for t < first(A.t)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)