### PR TITLE
Drop O3/NO2 from wet deposition (insoluble gases; GEOS-Chem WETDEP practice)

### DIFF
--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -228,8 +228,10 @@ function EarthSciMLBase.couple2(
         convert(System, c),
         d,
         Dict(
-            c.NO2 => d.k_othergas => -c.NO2,
-            c.O3 => d.k_othergas => -c.O3,
+            # NOTE: O3 and NO2 are intentionally NOT wet-deposited. GEOS-Chem does
+            # not wet-scavenge these sparingly-soluble gases (Hstar ~ 0.01); the EMEP
+            # `k_othergas` bucket would otherwise apply a spurious soluble-gas wet sink.
+            # Both retain dry deposition (k_O3 / k_NO2) in the dry-dep coupling.
             c.ACTA => d.k_othergas => -c.ACTA,
             c.ALD2 => d.k_othergas => -c.ALD2,
             c.AROMP4 => d.k_othergas => -c.AROMP4,

--- a/test/gaschem_wetdep_test.jl
+++ b/test/gaschem_wetdep_test.jl
@@ -1,0 +1,27 @@
+# Tests for the GasChem GEOSChemGasPhase <-> wet-deposition coupling (GasChemExt):
+# verify that O3 and NO2 are NOT wet-scavenged (GEOS-Chem does not wet-deposit
+# these sparingly-soluble gases), while a soluble species (HNO3) still is.
+
+@testitem "GEOSChem wet-dep excludes insoluble O3 and NO2" begin
+    using AtmosphericDeposition, GasChem, EarthSciMLBase, ModelingToolkit
+
+    sys = convert(System, couple(GEOSChemGasPhase(), WetDeposition()))
+
+    # RHS of a species' tendency equation, identified by its LHS (D(species)).
+    # Checking the RHS of the specific tendency avoids false positives from the
+    # species appearing as a reactant in another (wet-deposited) species' equation.
+    function tendency_rhs(sp)
+        for eq in equations(sys)
+            occursin("₊" * sp * "(t)", string(eq.lhs)) && return string(eq.rhs)
+        end
+        return nothing
+    end
+
+    # The wet-dep operator adds a `k_othergas` first-order sink. O3 and NO2 must not.
+    @test tendency_rhs("O3") !== nothing
+    @test !occursin("k_othergas", tendency_rhs("O3"))
+    @test tendency_rhs("NO2") !== nothing
+    @test !occursin("k_othergas", tendency_rhs("NO2"))
+    # Sanity: a soluble species (HNO3) still IS wet-deposited via k_othergas.
+    @test occursin("k_othergas", tendency_rhs("HNO3"))
+end


### PR DESCRIPTION

**bugfix · non-breaking**

## Motivation / Change
The `GEOSChemGasPhase ↔ WetDeposition` coupling currently routes O3 and NO2 through the EMEP `k_othergas` soluble-gas scavenging bucket. This PR removes those two entries from the wet-deposition Dict; every other species mapping is unchanged, and both species keep their dedicated dry-deposition channels (`k_O3` / `k_NO2`) in the dry-dep coupling.

## Why this departs from the current design
This intentionally removes an existing sink, so the case for it:

- **The current rate is unphysical for these gases.** `k_othergas` is the EMEP soluble-gas parameterization (sub-cloud/in-cloud scavenging ratios 0.5 / 1.4), calibrated for gases that actually partition into droplets. O3 and NO2 are sparingly soluble — effective Henry's-law constants of order 1e-2 M/atm, several orders of magnitude below the soluble species in this table (HNO3, H2O2, …) — so applying the generic soluble-gas rate imposes a spurious first-order wet sink on the two central photochemical species.
- **Reference practice.** GEOS-Chem's own wet-deposition (WETDEP) species table does not scavenge O3 or NO2, for exactly this solubility reason. Since this coupling wraps the GEOS-Chem gas-phase mechanism, the species list should follow the mechanism's deposition practice.
- **The real removal pathway is untouched.** Surface uptake of O3 and NO2 is a dry-deposition process; both retain `k_O3` / `k_NO2` in the dry-dep coupling, so this only removes the double-counted (and mis-parameterized) wet channel.
- **Internal consistency.** The repo's own SuperFast and Pollu (the Pollu benchmark mechanism) wet-dep Dicts already map only soluble species and exclude O3/NO2; the GEOSChem Dict was the sole coupling routing them through `k_othergas`, so this change also aligns the three couplings.

## Validation
- New testitem (`test/gaschem_wetdep_test.jl`): builds `couple(GEOSChemGasPhase(), WetDeposition())` and checks each species' *own* tendency RHS (matching by `D(species)` LHS, which avoids false positives from the species appearing as a reactant elsewhere): O3 and NO2 must contain no `k_othergas` sink, while a soluble control species (HNO3) still must. 5 new assertions, all green.
- Branch CI (full `Pkg.test`): failure set identical to the upstream/main baseline — the single pre-existing, version-sensitive `EarthSciDataExt` equation-string check (`connector_test.jl:72`); no new failures.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
