### PR TITLE
Dry-dep reference height: constant 30 m instead of Z_agl (fixes surface NaN; drops the 72-layer expression from the RHS)

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -24,6 +24,12 @@ MoninObhukovLength(ρ_air, Ts, u_star, HFLUX) = -ρ_air * Cp * Ts * (u_star)^3 /
 # First level pressure thickness using the first 2 values of Ap and Bp
 first_level_pressure_thickness(P) = -0.04804826 * P_unit + P * 0.015048
 
+# Constant aerodynamic-resistance reference height for surface gas dry deposition.
+# Deposition acts at lev=1, where the layer-bottom height above ground is 0, so a
+# height-above-ground reference would give log(z/z₀) = log(0) = NaN. A fixed 30 m
+# reference also keeps the multi-layer height interpolation out of the deposition RHS.
+@constants z_min_dep = 30.0 [unit = u"m", description = "Surface dry-deposition aerodynamic reference height"]
+
 function EarthSciMLBase.couple2(
         d::AtmosphericDeposition.DryDepositionGasCoupler,
         gp::EarthSciData.GEOSFPCoupler
@@ -35,7 +41,7 @@ function EarthSciMLBase.couple2(
     return ConnectorSystem(
         [
             d.Ts ~ gp.A1₊TS,
-            d.z ~ gp.Z_agl, 
+            d.z ~ z_min_dep,   # constant 30 m floor; height above ground is 0 at lev=1 → log(0) NaN
             d.del_P ~ first_level_pressure_thickness(gp.I3₊PS),
             d.z₀ ~ gp.A1₊Z0M,
             d.u_star ~ gp.A1₊USTAR,

--- a/test/connector_test.jl
+++ b/test/connector_test.jl
@@ -71,3 +71,26 @@ end
     wanteq = "WetDeposition₊cloudFrac(t) ~ GEOSFP₊A3cld₊CLOUD_itp(GEOSFP₊t_ref + t, GEOSFP₊lon, GEOSFP₊lat, GEOSFP₊lev)"
     @test contains(eqs, wanteq)
 end
+
+
+@testitem "dry-dep reference height is the constant floor (no Z_agl in RHS)" begin
+    using EarthSciMLBase, EarthSciData, Dates
+    using EarthSciMLBase: DomainInfo
+    t0 = DateTime(2016, 3, 10)
+    dom = DomainInfo(t0, t0 + Hour(3) + Hour(36);
+        lonrange = deg2rad(-88):deg2rad(0.625):deg2rad(-86),
+        latrange = deg2rad(32):deg2rad(0.5):deg2rad(33.5),
+        levrange = 1:2, u_proto = zeros(Float64, 1, 1, 1, 1))
+    gfp = EarthSciData.GEOSFP("0.25x0.3125", dom)
+    d = DryDepositionGas()
+    cs = EarthSciMLBase.couple2(EarthSciMLBase.get_coupletype(d)(d),
+                                EarthSciMLBase.get_coupletype(gfp)(gfp))
+    zeq = [e for e in cs.eqs if endswith(string(e.lhs), "₊z(t)")]
+    @test length(zeq) == 1
+    rhs = string(only(zeq).rhs)
+    # The reference height must stay a plain constant: referencing the
+    # height-above-ground field would be 0 at lev=1 (log(0) = NaN) and would inline
+    # the multi-layer interpolation cascade into the deposition RHS.
+    @test !occursin("Z_agl", rhs)
+    @test length(rhs) < 60
+end


### PR DESCRIPTION

**bugfix + perf · non-breaking**

## Motivation
The `DryDepositionGas ↔ GEOSFP` connector sets the aerodynamic reference height with `d.z ~ gp.Z_agl`. That has two independent problems:

1. **Correctness — it NaNs exactly where deposition acts.** Dry deposition is a surface process: the deposition velocity is gated by `ifelse(lev == 1, …)` in `DryDepositionGas`. Under EarthSciData 0.16 (the current release line, whose surface-anchored `Z_agl` definition states "Z_agl(1) = 0 by construction"), `Z_agl` is height above ground at the layer *bottom* edge, so at lev = 1 it is identically 0. The aerodynamic resistance evaluates `log(z/z₀)` → `log(0)` → NaN `ra`, and the coupled CTM goes `Unstable` at initialization. (0.15's older mid-layer `Z_agl` form did not hit the NaN, but that form predates upstream's own Z_agl height fix.)
2. **Cost — a 72-layer expression is inlined to deliver that 0.** In EarthSciData 0.16, `Z_agl` is a 72-layer `ifelse` cascade; referencing it made the dep `z` equation RHS ~118,907 characters (~144 4-D interpolations per grid cell per time step). The dep coupling is the coupled system's *only* `Z_agl` consumer, so this entire expression exists to compute a quantity that is identically 0 at the one level where it is used.

## Change
`d.z ~ z_min_dep`, a new 30 m constant (standard surface-layer reference height for dry deposition). The 72-layer `Z_agl` expression leaves the RHS entirely. The standalone `DryDepositionGas` default (`z = 60` m) is untouched — only the GEOSFP connector equation changes.

## Why this departs from the current design
Replacing a met-driven height with a constant looks like a downgrade, but no height information is lost: the deposition velocity is nonzero only at lev = 1, where `Z_agl ≡ 0` — the met-driven value never supplies a usable height there, it only supplies the NaN. A fixed 30 m reference height is the standard choice for a lev = 1 deposition calculation, and it is the only form that removes both failure modes at once (any expression still referencing `Z_agl` keeps the 72-layer cascade in the RHS; any floor/`max` form still inlines it).

The dep `z` RHS shrinks from 118,907 → 9 characters (reproducible: build the `DryDepositionGas ↔ GEOSFP` connector and inspect the single `z` equation). Author-side timings (not reproducible from this repo; single build, hardware unstated, your timings will vary): `convert(System)` 152.8 s → 28.9 s (~5.3×). The surface NaN / `Unstable`-at-init failure is gone after this change (reproduce by coupling `DryDepositionGas` with GEOSFP at EarthSciData 0.16 and building the system).

## Validation
- New guard testitem (`test/connector_test.jl`): builds the `DryDepositionGas ↔ GEOSFP` connector, extracts the single `z` equation, and asserts its RHS contains no `Z_agl` reference and stays a short constant expression (< 60 chars) — so a future coupling change cannot silently reintroduce the cascade.
- Branch CI (full `Pkg.test`): failure set identical to the upstream/main baseline (the one pre-existing, version-sensitive `EarthSciDataExt` equation-string check at `connector_test.jl:72`); the 3 new assertions pass.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
