### PR TITLE
SuperFast SO2/NH3 dry dep + SO2/NH3/SO4/NH4/NIT wet dep

### DIFF
--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -12,7 +12,12 @@ function EarthSciMLBase.couple2(
         convert(System, c),
         d,
         Dict(
-            #c.SO2 => d.SO2 => c.SO2, # SuperFast does not currently have SO2
+            # SO2 and NH3 dry deposition: both have fast Wesely deposition via
+            # dedicated k_SO2/k_NH3 channels. Without these sinks their emissions
+            # accumulate unphysically (NH3 -> ISORROPIA converts the excess to
+            # tens-of-ppb NH4 aerosol).
+            c.SO2 => d.k_SO2 => -c.SO2,
+            c.NH3 => d.k_NH3 => -c.NH3,
             c.HNO3 => d.k_HNO3 => -c.HNO3,
             c.NO2 => d.k_NO2 => -c.NO2,
             c.NO => d.k_NO2 => -c.NO,
@@ -33,7 +38,14 @@ function EarthSciMLBase.couple2(
         convert(System, c),
         d,
         Dict(
-            #c.SO2 => d.k_SO2 => c.SO2, # SuperFast does not currently have SO2
+            # Soluble gases SO2 (dedicated channel) + NH3 (highly
+            # soluble -> generic soluble-gas rate); aerosol species SO4/NH4/NIT
+            # scavenge at the particle rate.
+            c.SO2 => d.k_SO2 => -c.SO2,
+            c.NH3 => d.k_othergas => -c.NH3,
+            c.SO4 => d.k_particle => -c.SO4,
+            c.NH4 => d.k_particle => -c.NH4,
+            c.NIT => d.k_particle => -c.NIT,
             c.HNO3 => d.k_othergas => -c.HNO3,
             c.H2O2 => d.k_othergas => -c.H2O2,
             c.CH2O => d.k_othergas => -c.CH2O,


### PR DESCRIPTION

**feature · non-breaking**

## Motivation / Change
With SO2/NH3 re-enabled in SuperFast (GasChem SuperFast-aerosol-species PR), add their deposition channels to the two existing SuperFast couplings — this replaces the stale `# SuperFast does not currently have SO2` placeholder comments with actual mappings:

- **Dry dep:** SO2 and NH3 via their dedicated fast Wesely channels (`k_SO2` / `k_NH3`).
- **Wet dep:** SO2 via the dedicated EMEP `k_SO2` channel (SO2-specific scavenging ratios), NH3 (highly soluble) via `k_othergas`, and the aerosol species SO4/NH4/NIT via `k_particle`.

Without these sinks, NEI emissions of the new species accumulate unphysically — most visibly NH3, whose excess ISORROPIA converts into tens-of-ppb NH4 aerosol. All additions follow the sign/channel conventions already used by the surrounding entries; no existing mapping is modified.

Note on channel choice: aerosol species (SO4/NH4/NIT) use the particle scavenging rate `k_particle`. The existing GEOSChem wet-dep Dict currently routes SO4/SO4s/NIT/NITs through `k_othergas`; that Dict is left untouched here, and normalizing it to `k_particle` would be a separate follow-up.

## Validation
Upstream's existing `GasChemExt` SuperFast Dry/WetDep connector tests build exactly these couplings, so the new mappings are compile-exercised by the current suite as soon as the GasChem species exist (see merge order below); the suite's equation-string assertions cover the pre-existing entries. The NH3/NH4 sink behavior is expected on physical grounds (SO2/NH3/aerosol scavenging), but it is an author-side observation, not an in-repo test: in author-side coupled SuperFast-aerosol integration runs (not reproducible from this repo), this deposition wiring closed the NH3/NH4 accumulation described above.

## Dependencies / merge order (why this PR's CI is red until then)
Requires the **GasChem SuperFast-aerosol-species PR**. This repo's `[sources]` section pins GasChem to `git#main`, so CI for this branch currently errors with "SuperFast SO2 does not exist" in the `GasChemExt` connector tests — and will go green *automatically* once the GasChem PR merges to its main, with no version bump or re-push needed here. All other tests match the upstream baseline (the only failure is the pre-existing version-sensitive `connector_test.jl:72` equation-string check). Please merge the GasChem PR first; this is the intended release gate, not a defect in this branch.

---

### Review order - part of the coordinated train ([#225](https://github.com/EarthSciML/GasChem.jl/issues/225))

Base = `main`. Cut fresh from `main`. `[sources]` already pins GasChem `main` (upstream's own house pattern), so **CI auto-greens once the GasChem SuperFast-species PR merges** - no release needed. Merge after that PR.


*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
