### PR TITLE
Particle dry deposition for SO4/NH4/NIT

### DIFF
--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -355,4 +355,44 @@ function EarthSciMLBase.couple2(
     )
 end
 
+
+# ============================================================================
+# Particle (aerosol) dry deposition for SO4/NH4/NIT.
+# DryDepositionAerosol supplies a met-driven particle deposition rate k = v_d/z
+# (S&P 2006 Eq. 19.7; v_d ~ 0.05-0.2 cm/s for accumulation-mode particles).
+# Without this sink these aerosol species have wet deposition only, leaving no
+# dry-removal pathway and biasing multi-day aerosol burdens high.
+# ============================================================================
+function EarthSciMLBase.couple2(
+        c::GasChem.SuperFastCoupler,
+        d::AtmosphericDeposition.DryDepositionAerosolCoupler
+    )
+    c, d = c.sys, d.sys
+    return operator_compose(
+        convert(System, c),
+        d,
+        Dict(
+            c.SO4 => d.k => -c.SO4,
+            c.NH4 => d.k => -c.NH4,
+            c.NIT => d.k => -c.NIT
+        )
+    )
+end
+
+function EarthSciMLBase.couple2(
+        c::GasChem.GEOSChemGasPhaseCoupler,
+        d::AtmosphericDeposition.DryDepositionAerosolCoupler
+    )
+    c, d = c.sys, d.sys
+    return operator_compose(
+        convert(System, c),
+        d,
+        Dict(
+            c.SO4 => d.k => -c.SO4,
+            c.NH4 => d.k => -c.NH4,
+            c.NIT => d.k => -c.NIT
+        )
+    )
+end
+
 end


### PR DESCRIPTION

**feature · non-breaking**

## Motivation / Change
The aerosol species SO4/NH4/NIT have wet deposition only — no dry-deposition sink at all (upstream's GEOSChem wet-dep Dict already scavenges SO4/NIT; the SuperFast entries arrive with the SF-species PRs) — so without a dry-deposition sink these accumulation-mode species have only wet removal, and their burdens accumulate high over multi-day simulations. The repo already contains the physics (`DryDepositionAerosol`, Seinfeld & Pandis 2006 Eq. 19.7: met-driven `v_d` ~0.05–0.2 cm/s for accumulation-mode particles, applied as `k = v_d/z`); it was just never wired to a chemistry mechanism. This PR adds two new `couple2` methods (`SuperFastCoupler ↔ DryDepositionAerosolCoupler` and `GEOSChemGasPhaseCoupler ↔ DryDepositionAerosolCoupler`) mapping SO4/NH4/NIT to `d.k` as first-order sinks. Pure addition: no existing coupling, equation, or test is modified.

## Validation
Branch CI (full `Pkg.test`): failure set identical to the upstream/main baseline (the pre-existing version-sensitive `connector_test.jl:72` check). The new `couple2` methods are dispatch additions that upstream's current tests do not exercise — real exercise comes with the GasChem species release below, once those dependencies merge.

## Dependencies / merge order
- **GasChem NH3/NH4 PR** (ISORROPIA) — NH4 does not exist in upstream GasChem yet.
- **GasChem SuperFast-aerosol-species PR** — for the SuperFast SO4/NH4/NIT coupling.

This repo's `[sources]` pins GasChem to `git#main`, so once those GasChem PRs merge, the new couplings become active (and testable) automatically. A SO4/NIT-only variant of the GEOSChem coupling could merge earlier if preferred, since those species already exist upstream.

---

### Review order - part of the coordinated train ([#225](https://github.com/EarthSciML/GasChem.jl/issues/225))

Base = `main`. Stacked on SF-species-dep (#162); net-new = the particle-drydep commit. Same GasChem-SuperFast gate.


*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
