### PR TITLE
Deposition correctness fixes (6): in-cloud ratio, aerosol box thickness, Ap unit, NO channel, r_s guard, CH2O channel

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -21,8 +21,9 @@ air_density(P, T) = P / (T * R) * MW_air
 # Monin-Obhukov length = -Air density * Cp * T(surface air) * Ustar^3/（vK   * g  * Sensible Heat flux）
 MoninObhukovLength(ρ_air, Ts, u_star, HFLUX) = -ρ_air * Cp * Ts * (u_star)^3 / (vK * g * HFLUX)
 
-# First level pressure thickness using the first 2 values of Ap and Bp
-first_level_pressure_thickness(P) = -0.04804826 * P_unit + P * 0.015048
+# First level pressure thickness using the first 2 values of Ap and Bp.
+# Ap(2) = 0.04804826 hPa = 4.804826 Pa; the hPa value was inserted as Pa (100× too small).
+first_level_pressure_thickness(P) = -4.804826 * P_unit + P * 0.015048
 
 function EarthSciMLBase.couple2(
         d::AtmosphericDeposition.DryDepositionGasCoupler,
@@ -55,12 +56,13 @@ function EarthSciMLBase.couple2(
     )
     d, gp = d.sys, gp.sys
 
-    d = param_to_var(d, :Ts, :z, :z₀, :u_star, :ρA, :L, :lev)
+    d = param_to_var(d, :Ts, :z, :del_P, :z₀, :u_star, :ρA, :L, :lev)
 
     return ConnectorSystem(
         [
             d.Ts ~ gp.A1₊TS,
-            d.z ~ 0.1 * gp.A1₊PBLH, # the surface layer height is 10% of the boundary layer height
+            d.z ~ 0.1 * gp.A1₊PBLH, # Ra reference height only (surface layer = 10% of PBL)
+            d.del_P ~ first_level_pressure_thickness(gp.I3₊PS), # level-1 box thickness for k = v·g·ρA/del_P
             d.z₀ ~ gp.A1₊Z0M,
             d.u_star ~ gp.A1₊USTAR,
             d.ρA ~ air_density(gp.P, gp.I3₊T),

--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -18,7 +18,14 @@ function EarthSciMLBase.couple2(
             c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.H2O2 => d.k_H2O2 => -c.H2O2,
-            c.CH2O => d.k_HCHO => -c.CH2O
+            # k_CH2O (CH2OData: Hstar=3.0e3, f0=1.0 — matches the GEOS-Chem species
+            # database exactly), NOT the legacy Wesely-table k_HCHO (HchoData:
+            # Hstar=6.0e3, f0=0). f0=0 disables the surface-reactivity pathway and
+            # makes v_d(CH2O) ~15x too slow vs GEOS-Chem. The GEOSChemGasPhase
+            # coupling below already uses k_CH2O; this aligns SuperFast with it.
+            # (The Pollu benchmark coupling keeps k_HCHO deliberately — it is not a
+            # GEOS-Chem-fidelity target.)
+            c.CH2O => d.k_CH2O => -c.CH2O
         )
     )
 end

--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -15,7 +15,7 @@ function EarthSciMLBase.couple2(
             #c.SO2 => d.SO2 => c.SO2, # SuperFast does not currently have SO2
             c.HNO3 => d.k_HNO3 => -c.HNO3,
             c.NO2 => d.k_NO2 => -c.NO2,
-            c.NO => d.k_NO2 => -c.NO,
+            c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.H2O2 => d.k_H2O2 => -c.H2O2,
             c.CH2O => d.k_HCHO => -c.CH2O
@@ -55,7 +55,7 @@ function EarthSciMLBase.couple2(
             #c.SO2 => d.SO2 => c.SO2, # Pollu does not currently include SO2
             c.HNO3 => d.k_HNO3 => -c.HNO3,
             c.NO2 => d.k_NO2 => -c.NO2,
-            c.NO => d.k_NO2 => -c.NO,
+            c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.PAN => d.k_PAN => -c.PAN,
             c.CH2O => d.k_HCHO => -c.CH2O

--- a/src/dry_deposition.jl
+++ b/src/dry_deposition.jl
@@ -1057,6 +1057,7 @@ function DryDepositionAerosol(; name = :DryDepositionAerosol)
         Dp = 0.8e-6, [unit = u"m", description = "Particle diameter"]
         P = 101325, [unit = u"Pa", description = "Pressure"]
         ρParticle = 1000.0, [unit = u"kg*m^-3", description = "Particle density"]
+        del_P = 1520, [unit = u"Pa", description = "Pressure thickness of level 1"]
     end
 
     @variables begin
@@ -1068,7 +1069,11 @@ function DryDepositionAerosol(; name = :DryDepositionAerosol)
             lev, z, z₀, u_star, L, Dp, Ts, P, ρParticle, ρA,
             SeinfeldSeason, WesleySeason, SeinfeldLandUse, WesleyLandUse
         ),
-        k ~ v / z,
+        # Convert deposition velocity to a first-order rate with the level-1 grid-box
+        # thickness Δz = del_P/(g·ρA) (~129 m), exactly as the gas path does at
+        # `deprate = depvel·g·ρA/del_P` — NOT z (= 0.1·PBLH, the Ra reference height).
+        # The old k = v/z over-deposited aerosol several-fold at night / under at midday.
+        k ~ v * g * ρA / del_P,
     ]
 
     return System(

--- a/src/wesley1989.jl
+++ b/src/wesley1989.jl
@@ -255,9 +255,9 @@ function r_s(G, Ts, iSeason, iLandUse, rainOrDew::Bool)
     rs = ifelse(
         (Ts <= 0.1),
         inf,
-        obtain_value(iSeason, iLandUse, r_i) *
-            (1 + (200.0 * 1.0 / (G + 1.0))^2) *
-            (400.0 * 1.0 / (Ts * (40.0 - Ts)))
+        rs   # carry forward the Ts>=39.9 hot-closure guard above; re-evaluating the
+        # eq-3 expression here discarded it, so stomata never closed for Ts>40°C
+        # and r_s went negative (via the (40-Ts) factor)
     )
     # Adjust for dew and rain (from "Effects of dew and rain" section).
     if rainOrDew

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -121,8 +121,8 @@ function _WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     # wd (in-cloud) = wIn * P / Δz / ρwater = wIn * QRAIN * Vdr * ρgas / Δz / ρwater
 
     wdParticle = i * qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / Δz))
-    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wSubSO2VdrPerρwater) * qrain * ρ_air / Δz
-    wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wSubOtherVdrPerρwater) * qrain *
+    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wInSO2VdrPerρwater) * qrain * ρ_air / Δz
+    wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wInOtherVdrPerρwater) * qrain *
         ρ_air / Δz
 
     return wdParticle, wdSO2, wdOtherGas

--- a/test/connector_test.jl
+++ b/test/connector_test.jl
@@ -26,7 +26,10 @@ end
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_NO2")
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_O3")
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_H2O2")
-    @test contains(eqs, "SuperFast₊DryDepositionGas_k_HCHO")
+    # CH2O uses the GEOS-Chem-aligned k_CH2O channel (CH2OData: Hstar=3e3, f0=1.0),
+    # not the legacy Wesely-table k_HCHO (f0=0) - see the coupling in ext/GasChemExt.jl.
+    @test contains(eqs, "SuperFast₊DryDepositionGas_k_CH2O")
+    @test !contains(eqs, "SuperFast₊DryDepositionGas_k_HCHO")
 end
 
 @testitem "GasChemExt SuperFast WetDeposition" begin


### PR DESCRIPTION
## Summary

Five **independent, separable** correctness fixes found by a module-by-module equivalence audit of this package vs GEOS-Chem Classic 14.7.1. Each is small and self-contained — happy to split into separate PRs if preferred.

1. **Wet dep — in-cloud gas ratio** (`wet_deposition.jl`): the in-cloud (`cloudFrac`-weighted) term for SO₂ and other gases used the **sub-cloud** ratio (`wSubSO2=0.15` / `wSubOther=0.5`) instead of the in-cloud one (`wInSO2=0.3` / `wInOther=1.4`), ~halving in-cloud gas scavenging. The particle path already used `wInParticle` correctly.
2. **Aerosol dry-dep box thickness** (`dry_deposition.jl` + `ext/EarthSciDataExt.jl`): `DryDepositionAerosol` converted velocity→rate with `k = v/z`, where `z` is the aerodynamic reference height (`0.1·PBLH`), not the depth of the grid box. Now `k = v·g·ρA/del_P` (Δz≈129 m) — matching the gas path (`deprate = depvel·g·ρA/del_P`). Adds a `del_P` param and wires it in the aerosol GEOSFP `couple2`.
3. **Ap unit** (`ext/EarthSciDataExt.jl`): `first_level_pressure_thickness` used `Ap(2)=0.04804826` **hPa** as **Pa** (100× too small); corrected to `4.804826` Pa.
4. **NO dry-dep channel** (`ext/GasChemExt.jl`): NO was routed through NO₂'s rate (`k_NO2`); NO is far less surface-reactive/soluble, so it uses its own dedicated `k_NO` (SuperFast + Pollu couplings).
5. **Stomatal `r_s` hot guard** (`wesley1989.jl`): the second `ifelse` re-evaluated the eq-3 expression in its else-branch, discarding the `Ts≥39.9 °C` hot-closure guard → `r_s` went **negative** for `Ts>40 °C` (via the `(40−Ts)` factor). Now it carries the guarded value forward.

## Verification

Each fix cross-checked in-repo: #1 vs the correct `wInParticle` path; #2/#3 vs the gas path's `del_P` normalization; #4 vs the distinct declared `k_NO`/`k_NO2` channels; #5 vs the guard it was meant to preserve. Diff is small (5 files, +19/−12).

Found by an equivalence audit vs GEOS-Chem 14.7.1; part of the Stage 6 addendum in EarthSciML/GasChem.jl#225.

---

## 6. SuperFast CH2O dry-dep channel: `k_HCHO` → `k_CH2O` *(added after the round-2 numerical audit)*

The SuperFast coupling deposited CH2O via the legacy Wesely-table channel `k_HCHO` (`HchoData`: Hstar=6.0e3, **f0=0**). With f0=0 the surface-reactivity pathway (`r_gsO`/`r_clO`) is disabled, giving Rc ≈ 6770 s/m and v_d(CH2O) ≈ 0.015 cm/s — **~15× slower than GEOS-Chem**. The GEOS-Chem species database specifies `DD_Hstar: 3.0e+3, DD_F0: 1.0` for CH2O, which is exactly `CH2OData`/`k_CH2O` — the channel the GEOSChemGasPhase coupling in the same file already uses.

Same defect class as fix 4 (NO mis-routed through `k_NO2`). The Pollu benchmark coupling keeps `k_HCHO` deliberately (Pollu is not a GEOS-Chem-fidelity target). The connector test now pins the corrected channel and rejects a regression to `k_HCHO`.
