### PR TITLE
Wet deposition: restore the EMEP 1e6 scavenging-ratio scale + fixed h_s scavenging depth (gas wet dep was a numerical no-op)

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -21,8 +21,9 @@ air_density(P, T) = P / (T * R) * MW_air
 # Monin-Obhukov length = -Air density * Cp * T(surface air) * Ustar^3/（vK   * g  * Sensible Heat flux）
 MoninObhukovLength(ρ_air, Ts, u_star, HFLUX) = -ρ_air * Cp * Ts * (u_star)^3 / (vK * g * HFLUX)
 
-# First level pressure thickness using the first 2 values of Ap and Bp
-first_level_pressure_thickness(P) = -0.04804826 * P_unit + P * 0.015048
+# First level pressure thickness using the first 2 values of Ap and Bp.
+# Ap(2) = 0.04804826 hPa = 4.804826 Pa; the hPa value was inserted as Pa (100× too small).
+first_level_pressure_thickness(P) = -4.804826 * P_unit + P * 0.015048
 
 function EarthSciMLBase.couple2(
         d::AtmosphericDeposition.DryDepositionGasCoupler,
@@ -55,12 +56,13 @@ function EarthSciMLBase.couple2(
     )
     d, gp = d.sys, gp.sys
 
-    d = param_to_var(d, :Ts, :z, :z₀, :u_star, :ρA, :L, :lev)
+    d = param_to_var(d, :Ts, :z, :del_P, :z₀, :u_star, :ρA, :L, :lev)
 
     return ConnectorSystem(
         [
             d.Ts ~ gp.A1₊TS,
-            d.z ~ 0.1 * gp.A1₊PBLH, # the surface layer height is 10% of the boundary layer height
+            d.z ~ 0.1 * gp.A1₊PBLH, # Ra reference height only (surface layer = 10% of PBL)
+            d.del_P ~ first_level_pressure_thickness(gp.I3₊PS), # level-1 box thickness for k = v·g·ρA/del_P
             d.z₀ ~ gp.A1₊Z0M,
             d.u_star ~ gp.A1₊USTAR,
             d.ρA ~ air_density(gp.P, gp.I3₊T),

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -85,13 +85,17 @@ function EarthSciMLBase.couple2(
     # From EMEP algorithm: P = QRAIN * Vdr * ρgas => QRAIN = P / Vdr / ρgas
     # kg*m-2*s-1/(m/s)/(kg/m3)
 
-    d = param_to_var(d, :cloudFrac, :ρ_air, :qrain, :lev)
+    # lev is deliberately NOT promoted or linked: with the EMEP fixed-h_s rate
+    # form the rates no longer divide by the local layer thickness, so Delta-z (and
+    # lev, which only entered through get_lev_depth(lev) * Delta-z_unit) is unused
+    # in the WetDeposition equations and is pruned at convert time; promoting
+    # or linking it here throws "variable lev does not exist".
+    d = param_to_var(d, :cloudFrac, :ρ_air, :qrain)
     return ConnectorSystem(
         [
             d.cloudFrac ~ g.A3cld₊CLOUD,
             d.ρ_air ~ air_density(g.P, g.I3₊T),
             d.qrain ~ (g.A3mstE₊PFLCU + g.A3mstE₊PFLLSAN) / Vdr / (g.P / (g.I3₊T * R) * MW_air),
-            d.lev ~ g.lev,
         ],
         d,
         g

--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -18,7 +18,14 @@ function EarthSciMLBase.couple2(
             c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.H2O2 => d.k_H2O2 => -c.H2O2,
-            c.CH2O => d.k_HCHO => -c.CH2O
+            # k_CH2O (CH2OData: Hstar=3.0e3, f0=1.0 — matches the GEOS-Chem species
+            # database exactly), NOT the legacy Wesely-table k_HCHO (HchoData:
+            # Hstar=6.0e3, f0=0). f0=0 disables the surface-reactivity pathway and
+            # makes v_d(CH2O) ~15x too slow vs GEOS-Chem. The GEOSChemGasPhase
+            # coupling below already uses k_CH2O; this aligns SuperFast with it.
+            # (The Pollu benchmark coupling keeps k_HCHO deliberately — it is not a
+            # GEOS-Chem-fidelity target.)
+            c.CH2O => d.k_CH2O => -c.CH2O
         )
     )
 end

--- a/ext/GasChemExt.jl
+++ b/ext/GasChemExt.jl
@@ -15,7 +15,7 @@ function EarthSciMLBase.couple2(
             #c.SO2 => d.SO2 => c.SO2, # SuperFast does not currently have SO2
             c.HNO3 => d.k_HNO3 => -c.HNO3,
             c.NO2 => d.k_NO2 => -c.NO2,
-            c.NO => d.k_NO2 => -c.NO,
+            c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.H2O2 => d.k_H2O2 => -c.H2O2,
             c.CH2O => d.k_HCHO => -c.CH2O
@@ -55,7 +55,7 @@ function EarthSciMLBase.couple2(
             #c.SO2 => d.SO2 => c.SO2, # Pollu does not currently include SO2
             c.HNO3 => d.k_HNO3 => -c.HNO3,
             c.NO2 => d.k_NO2 => -c.NO2,
-            c.NO => d.k_NO2 => -c.NO,
+            c.NO => d.k_NO => -c.NO,
             c.O3 => d.k_O3 => -c.O3,
             c.PAN => d.k_PAN => -c.PAN,
             c.CH2O => d.k_HCHO => -c.CH2O

--- a/src/dry_deposition.jl
+++ b/src/dry_deposition.jl
@@ -1057,6 +1057,7 @@ function DryDepositionAerosol(; name = :DryDepositionAerosol)
         Dp = 0.8e-6, [unit = u"m", description = "Particle diameter"]
         P = 101325, [unit = u"Pa", description = "Pressure"]
         ρParticle = 1000.0, [unit = u"kg*m^-3", description = "Particle density"]
+        del_P = 1520, [unit = u"Pa", description = "Pressure thickness of level 1"]
     end
 
     @variables begin
@@ -1068,7 +1069,11 @@ function DryDepositionAerosol(; name = :DryDepositionAerosol)
             lev, z, z₀, u_star, L, Dp, Ts, P, ρParticle, ρA,
             SeinfeldSeason, WesleySeason, SeinfeldLandUse, WesleyLandUse
         ),
-        k ~ v / z,
+        # Convert deposition velocity to a first-order rate with the level-1 grid-box
+        # thickness Δz = del_P/(g·ρA) (~129 m), exactly as the gas path does at
+        # `deprate = depvel·g·ρA/del_P` — NOT z (= 0.1·PBLH, the Ra reference height).
+        # The old k = v/z over-deposited aerosol several-fold at night / under at midday.
+        k ~ v * g * ρA / del_P,
     ]
 
     return System(

--- a/src/wesley1989.jl
+++ b/src/wesley1989.jl
@@ -255,9 +255,9 @@ function r_s(G, Ts, iSeason, iLandUse, rainOrDew::Bool)
     rs = ifelse(
         (Ts <= 0.1),
         inf,
-        obtain_value(iSeason, iLandUse, r_i) *
-            (1 + (200.0 * 1.0 / (G + 1.0))^2) *
-            (400.0 * 1.0 / (Ts * (40.0 - Ts)))
+        rs   # carry forward the Ts>=39.9 hot-closure guard above; re-evaluating the
+        # eq-3 expression here discarded it, so stomata never closed for Ts>40°C
+        # and r_s went negative (via the (40-Ts) factor)
     )
     # Adjust for dew and rain (from "Effects of dew and rain" section).
     if rainOrDew

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -3,6 +3,7 @@ export WetDeposition
 @constants A_wd = 5.2 [unit = u"m^3/kg/s", description = "Empirical coefficient"]
 @constants ρwater = 1000.0 [unit = u"kg*m^-3", description = "water density"]
 @constants Vdr = 5.0 [unit = u"m/s", description = "raindrop fall speed"]
+@constants h_s = 1000.0 [unit = u"m", description = "EMEP characteristic scavenging depth (Simpson et al. 2003, EMEP Status Report 1/2003 Part I, Ch. 9)"]
 
 const lev_depth = [
     123.66503647136699,
@@ -100,11 +101,18 @@ Outputs are wet deposition rates for PM2.5, SO2, and other gases
 """
 function _WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     E = 0.1           # size-dependent collection efficiency of aerosols by the raindrops
-    wSubSO2 = 0.15   # sub-cloud scavenging ratio
-    wSubOther = 0.5  # sub-cloud scavenging ratio
-    wInSO2 = 0.3     # in-cloud scavenging ratio
-    wInParticle = 1.0 # in-cloud scavenging ratio
-    wInOther = 1.4   # in-cloud scavenging ratio
+    # Scavenging ratios W-bar (dimensionless c_precip/c_air). EMEP Status Report
+    # 1/2003 Table 9.1 tabulates W-bar x 1e-6, i.e. the physical ratios are the
+    # table entries TIMES 1e6 (a fully-partitioned soluble gas saturates at
+    # W = 1/L = 1e6 for the EMEP precipitation liquid-volume fraction L = 1e-6;
+    # HNO3's 1.4e6 is at that limit). The bare table entries were previously used
+    # directly, making gas and in-cloud-particle wet deposition a numerical
+    # no-op (e-folding lifetimes of YEARS instead of hours).
+    wSubSO2 = 0.15e6   # sub-cloud scavenging ratio, SO2
+    wSubOther = 0.5e6  # sub-cloud scavenging ratio, other soluble gases
+    wInSO2 = 0.3e6     # in-cloud scavenging ratio, SO2
+    wInParticle = 1.0e6 # in-cloud scavenging ratio, particles
+    wInOther = 1.4e6   # in-cloud scavenging ratio, other soluble gases
 
     i = ifelse(qrain > 0, 1, 0) # index to check if rain is present, avoid negative qrain
 
@@ -120,10 +128,16 @@ function _WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     # wdGas (subcloud) = wSub * P / Δz / ρwater = wSub * QRAIN * Vdr * ρgas / Δz / ρwater
     # wd (in-cloud) = wIn * P / Δz / ρwater = wIn * QRAIN * Vdr * ρgas / Δz / ρwater
 
-    wdParticle = i * qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / Δz))
-    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wInSO2VdrPerρwater) * qrain * ρ_air / Δz
+    # EMEP rate form: k = W-bar * P / (h_s * ρwater), with P = qrain * Vdr * ρ_air
+    # and the FIXED characteristic scavenging depth h_s = 1000 m (NOT the local
+    # layer thickness Δz: dividing by Δz makes every layer independently remove
+    # the rain's full carrying capacity, over-scavenging the column by h_s/Δz per
+    # layer). Δz remains an argument for API compatibility but no longer enters
+    # the EMEP gas / in-cloud rates.
+    wdParticle = i * qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / h_s))
+    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wInSO2VdrPerρwater) * qrain * ρ_air / h_s
     wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wInOtherVdrPerρwater) * qrain *
-        ρ_air / Δz
+        ρ_air / h_s
 
     return wdParticle, wdSO2, wdOtherGas
 end

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -121,8 +121,8 @@ function _WetDeposition(cloudFrac, qrain, ρ_air, Δz)
     # wd (in-cloud) = wIn * P / Δz / ρwater = wIn * QRAIN * Vdr * ρgas / Δz / ρwater
 
     wdParticle = i * qrain * ρ_air * (AE + cloudFrac * (wInParticleVdrPerρwater / Δz))
-    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wSubSO2VdrPerρwater) * qrain * ρ_air / Δz
-    wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wSubOtherVdrPerρwater) * qrain *
+    wdSO2 = i * (wSubSO2VdrPerρwater + cloudFrac * wInSO2VdrPerρwater) * qrain * ρ_air / Δz
+    wdOtherGas = i * (wSubOtherVdrPerρwater + cloudFrac * wInOtherVdrPerρwater) * qrain *
         ρ_air / Δz
 
     return wdParticle, wdSO2, wdOtherGas

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -166,8 +166,6 @@ function WetDeposition(; name = :WetDeposition)
         [description = "rain mixing ratio"],
         ρ_air = 1.204,
         [unit = u"kg*m^-3", description = "air density"],
-        lev = 1,
-        [description = "level of the grid cell"],
     )
 
     @constants Δz_unit = 1 [unit = u"m", description = "unit depth"]
@@ -179,7 +177,7 @@ function WetDeposition(; name = :WetDeposition)
     end
 
     wdParticle, wdSO2,
-        wdOtherGas = _WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(lev) * Δz_unit)
+        wdOtherGas = _WetDeposition(cloudFrac, qrain, ρ_air, get_lev_depth(1) * Δz_unit)
 
     eqs = [k_particle ~ wdParticle, k_SO2 ~ wdSO2, k_othergas ~ wdOtherGas]
 

--- a/src/wet_deposition.jl
+++ b/src/wet_deposition.jl
@@ -141,7 +141,7 @@ function _WetDeposition(cloudFrac, qrain, ρ_air, Δz)
 
     return wdParticle, wdSO2, wdOtherGas
 end
-wd_defaults = [A_wd => 5.2, ρwater => 1000.0, Vdr => 5.0]
+wd_defaults = [A_wd => 5.2, ρwater => 1000.0, Vdr => 5.0, h_s => 1000.0]
 
 struct WetDepositionCoupler
     sys::Any
@@ -187,7 +187,7 @@ function WetDeposition(; name = :WetDeposition)
         eqs,
         t,
         vars,
-        [params; [Δz_unit, Vdr, A_wd, ρwater]],
+        [params; [Δz_unit, Vdr, A_wd, ρwater, h_s]],
         name = name,
         metadata = Dict(CoupleType => WetDepositionCoupler)
     )

--- a/test/connector_test.jl
+++ b/test/connector_test.jl
@@ -26,7 +26,10 @@ end
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_NO2")
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_O3")
     @test contains(eqs, "SuperFast₊DryDepositionGas_k_H2O2")
-    @test contains(eqs, "SuperFast₊DryDepositionGas_k_HCHO")
+    # CH2O uses the GEOS-Chem-aligned k_CH2O channel (CH2OData: Hstar=3e3, f0=1.0),
+    # not the legacy Wesely-table k_HCHO (f0=0) - see the coupling in ext/GasChemExt.jl.
+    @test contains(eqs, "SuperFast₊DryDepositionGas_k_CH2O")
+    @test !contains(eqs, "SuperFast₊DryDepositionGas_k_HCHO")
 end
 
 @testitem "GasChemExt SuperFast WetDeposition" begin

--- a/test/wetdep_test.jl
+++ b/test/wetdep_test.jl
@@ -26,7 +26,9 @@ end
             _WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1],
             Dict(cloudFrac => 0.5, qrain => 0.5, ρ_air => 1.204, Δz => 200, wd_defaults...)
         )
-    ) ≈ 0.313047525
+    ) ≈ 1.81804  # = qrain*ρ_air*(A_wd*E + cf*W_in,particle*Vdr/(ρwater*h_s)) with the
+    # EMEP 1e6 scavenging-ratio scale + fixed h_s=1000 m (was 0.313047525 when the
+    # in-cloud term used the bare Table-9.1 entry and the local Δz)
     @test ModelingToolkit.get_unit(_WetDeposition(cloudFrac, qrain, ρ_air, Δz)[1]) ==
         u"s^-1"
     @test ModelingToolkit.get_unit(_WetDeposition(cloudFrac, qrain, ρ_air, Δz)[2]) ==


### PR DESCRIPTION
## Summary

The EMEP scavenging ratios W̄ (Simpson et al., EMEP Status Report 1/2003, Table 9.1) are tabulated as **W̄ × 10⁻⁶** — the physical dimensionless ratios are the table entries **× 1e6**. The code used the bare table entries (0.15 / 0.5 / 0.3 / 1.0 / 1.4) directly, making gas and in-cloud-particle wet deposition a **numerical no-op**: at 2 mm/h rain the HNO3/H2O2 e-folding lifetime evaluated to **6.2 years** (SO2: 25 years) instead of the expected sub-hour scale.

**Why 1e6 is certain** (three independent checks):
1. **Saturation physics:** a fully-partitioned soluble gas saturates at W = c_rain/c_air = 1/L = **1e6** for EMEP's precipitation liquid-volume fraction L = 1e-6. HNO3's tabulated 1.4(e6) sits at that limit; a literal W=1.4 would mean c_rain ≈ c_air — absurd for a gas with H* ~ 1e11 M/atm.
2. **GEOS-Chem cross-derivation:** GC's own Henry-law machinery (henry_mod `CALC_KH` → `L2G` → F_L, with COND_WATER = 1e-6) gives W = F_L/L = 0.15e6–1.0e6 for CH2O/H2O2/NH3/HNO3 — reproducing the EMEP entries ×1e6 in both rank order and magnitude.
3. **Forward agreement:** with the scale restored, the in-cloud aerosol rate (2.78e-4 s⁻¹ at 2 mm/h) matches GC 14.7.1's large-scale rainout for the same event (2.69e-4 s⁻¹) to 3%.

Restoring the scale exposes a second, compounding geometry error: the rates divided by the **local layer thickness Δz**, which makes every model layer independently remove the rain's full carrying capacity (over-scavenging the column by h_s/Δz per layer). EMEP's published rate is W̄·P/(h_s·ρ_water) with the **fixed characteristic scavenging depth h_s = 1000 m**; both are corrected together. The sub-cloud particle path (A·E·P/Vdr) was already correct and is untouched.

## Resulting rates (2 mm/h, cloudFrac = 0.5)

| Species | before (deployed) | after | expectation |
|---|---|---|---|
| HNO3/H2O2 (gas) | τ = **6.2 years** | τ = 25 min | washout ~tens of min–hours |
| SO2 | τ = 25 years | τ = 1.7 h | ~hours |
| in-cloud particle | τ = 15 years | τ = 1.0 h | GC same-event rainout: 1.03 h |

## Expected model impact

Activates a previously-inert sink: HNO3/H2O2/CH2O/CH3OOH (and SO2/aerosol) columns drop substantially in precipitating regions. In a SuperFast April CONUS run this **lowers** surface O3 by ~0.5–2 ppb in the wet Southeast (jH2O2→2OH HOx-reservoir stripping) — i.e. this bug was *masking* part of an existing low bias, and the fix is reported for correctness, not to tune skill.

## Review order

Stacked on #164 (`fix/deposition-audit-corrections`) — same file; merge after it. Found by a numerical equivalence audit of this stack against GEOS-Chem Classic 14.7.1; part of the Stage-6 series in EarthSciML/GasChem.jl#225.

## Follow-up (2026-07-26)

`fcec31a` — WetDeposition × GEOSFP coupler: drop the now-dead `lev` linkage. The fixed-h_s rate form removed Δz from all three scavenging rates, so `lev` — which only entered the WetDeposition equations through `get_lev_depth(lev) * Δz_unit` — became unused and is pruned at convert time. The unchanged coupler still promoted/linked it and threw `System WetDeposition: variable lev does not exist` on any full-composition `convert`. Caught by the first full-CTM build of the deployed Stage-6 stack; the `lev` param remains in `WetDeposition` for API compatibility and simply prunes.


## Follow-up 2 (2026-07-27)

`84c3281` — completes the coupler fix: `fcec31a` removed the `lev` linkage but left the dead `lev` *parameter* in the system, which then collided with `GEOSFP₊lev` in `coord_params` ("multiple matches in system parameters") on full-composition convert. The parameter is now removed from the `WetDeposition` constructor (fixed value `1` is passed to `get_lev_depth`, preserving the public `_WetDeposition` 4-arg signature and `wetdep_test.jl`). Verified end-to-end on a clean env: original code reproduces `variable lev does not exist`; coupler fix alone reproduces the `lev` ambiguity; the complete fix passes `coord_params` with a unique `GEOSFP₊lev`.
